### PR TITLE
Add link to live assessments on PrairieLearn

### DIFF
--- a/src/lib/gallery/assessments.ts
+++ b/src/lib/gallery/assessments.ts
@@ -14,7 +14,9 @@ export const ASSESSMENTS_ROOT = path.join(
   "assessments"
 );
 
-export interface Assessment extends MarkdownPage {}
+export interface Assessment extends MarkdownPage {
+  prairielearnUrl: string | null;
+}
 
 let cachedAssessments: Assessment[];
 
@@ -38,7 +40,11 @@ export const getAssessments = async (): Promise<Assessment[]> => {
         const docsMarkdown = await fs.readFile(docsMarkdownPath, "utf-8");
         const {
           content,
-          data: { title = "NO TITLE", summary = "NO SUMMARY" },
+          data: {
+            title = "NO TITLE",
+            summary = "NO SUMMARY",
+            prairielearn_url: prairielearnUrl = null,
+          },
         } = matter(docsMarkdown);
 
         return {
@@ -47,6 +53,7 @@ export const getAssessments = async (): Promise<Assessment[]> => {
           summary: summary,
           markdownContent: content,
           markdownPath: docsMarkdownPath,
+          prairielearnUrl,
         };
       })
     )

--- a/src/pages/gallery/[...slug].tsx
+++ b/src/pages/gallery/[...slug].tsx
@@ -19,12 +19,14 @@ interface GalleryPageProps {
   source: string;
   summary: string;
   title: string;
+  prairielearnUrl?: string | null;
 }
 
 const GalleryPage: React.FC<GalleryPageProps> = ({
   summary,
   source,
   title,
+  prairielearnUrl,
 }) => {
   const content = hydrate(source);
   return (
@@ -36,6 +38,11 @@ const GalleryPage: React.FC<GalleryPageProps> = ({
         <div className="my-5">
           <h1 className="display-3">{title}</h1>
           {summary && <p className="lead">{summary}</p>}
+          {prairielearnUrl && (
+            <a href={prairielearnUrl} className="btn btn-primary mt-2">
+              View on PrairieLearn
+            </a>
+          )}
         </div>
         <MDXProvider components={mdxComponents}>{content}</MDXProvider>
       </div>
@@ -106,6 +113,7 @@ export const getStaticProps: GetStaticProps<
           source: mdxSource,
           summary: assessment.summary,
           title: assessment.title,
+          prairielearnUrl: assessment.prairielearnUrl,
         },
       };
     }


### PR DESCRIPTION
Uses the new `prairielearn_url` in documentation front matter to offer button links to the live assessment on PrairieLearn.