### PR TITLE
Drop next-build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
     "build": "next build",
-    "next-build": "next build",
+    "dev": "next dev",
     "format": "prettier --write src/",
     "lint": "next lint && prettier --check src/",
     "start": "next start"


### PR DESCRIPTION
`next-build` and `build` were synonymous - we can drop the former.