### PR TITLE
Add Terms of Service and Privacy Policy

### DIFF
--- a/legal/privacy.md
+++ b/legal/privacy.md
@@ -1,0 +1,97 @@
+---
+title: Privacy Policy
+---
+
+PrairieLearn is an open-source learning platform. PrairieLearn, Inc. (“we”, “us”, or “our”) is a company created to provide hosting and support for the PrairieLearn software at [prairielearn.com](/) (the "Site"). This document explains our policies regarding the collection, usage, processing, disclosure and security of your Personal Information when using the software provided by PrairieLearn, Inc. (the “Service”). By using the Site, you agree to the collection and use of information in accordance with this policy, which apply to all visitors, students, teachers, instructors, administrators, and others who access the Service (“Users”). If you are using the Site in accordance with a PrairieLearn contract with a university, school, college or legal entity (“Institution”), that Institution may separately require you to confirm acceptance of privacy and related provisions established by the Institution regarding your use of the Service.
+
+We are the controller for Personal Information submitted to us under this Privacy Policy. PrairieLearn, Inc. takes its customers’ data privacy rights very seriously and has enacted this Policy to ensure those rights are maintained and protected. 
+
+## Revisions
+
+We will periodically review this Privacy Policy for accuracy and compliance, and we will notify you of these changes by posting them on the Site or by sending you an email. Any information that we collect is subject to the Privacy Policy in effect at the time you provide any Personal Information. You should review this Privacy Policy periodically.
+
+## Data collected and its usage
+
+### Information provided by the User directly to PrairieLearn
+
+While using our Site, Users need to create an account or use their Institution login credentials. PrairieLearn may have access to certain personally identifiable information, hereinafter referred to as your “Personal Information”, that may include, but is not limited to the following: first and last name, email address and phone number, institution name, password, and credit card information. This Personal Information is used to carry out actions you request through the Site, such as user support, order history, and Service payment.
+
+We also may retain information on your behalf, such as files and messages that you store using your account. If you provide us feedback or contact us via email, we will collect your name and email address, as well as any other content included in the email. 
+
+**Communications:** We may use your Personal Information to contact you with software updates and other information regarding your use of the Service. Course owners using the free Service may receive emails with product updates, promotional messages, surveys and other communications.
+
+### Information collected automatically related to the use of the Service
+
+When a User joins a course on the Services as a student, we get access to their email address and possibly their student identification number. In addition, we collect information about their interactions with the Site and their educational records, such as submitted assignments and corresponding scores. These User interactions on the Site while using the Service are referred as “Log Data”. PrairieLearn may send Log Data to a Learning Management System. Log Data may also include the User device’s Internet Protocol (“IP”) address, browser type, and operating system when using the Site. This information is used for purposes of providing the Service, validation and verification of a user account, tracking of transactions that you perform through the Site, security, improvement of the Services, and other purposes. We may use a person’s IP address to combat spam, malware, and identity theft, and to protect the integrity of the Service.
+
+**De-identified information:** We may use the information we obtain via the Services (as described above) to create de-identified data, which is a collection of information where the User cannot be identified as an individual. Nothing in this Privacy Policy is intended to limit our ability to generate and use de-identified data, including aggregated de-identified information.
+
+### Information collected using cookies
+
+Web Cookies are small pieces of data created by web servers and sent to your computer while you are browsing a website. We may use session cookies (which expire once you close your web browser) and persistent cookies (which stay on your computer until you delete them) to provide you with a more personal and interactive experience on our Site. Most web browsers are set to accept cookies by default. You may choose to set your web browser to refuse cookies, or to alert you when cookies are being sent. If you do so, note that some parts of our Site and Services may not function properly. We do not use web beacons or flash cookies.
+
+### Information collected for analytics
+
+We use analytics services from Google Analytics to help analyze how users use the Site. These services use cookies and scripts to collect and store information such as how users interact with our Service, errors users encounter when using our Site and general User statistics. We use this information to improve our Site and Services. We do not tie the information gathered using third party analytics to your personally identifiable information.
+
+### Other general use of Personal Information
+
+In addition to the specific uses described above, we may also make use of Personal Information for the following purposes: 
+
+- Improve the Site and our products and services;
+- Deliver and support our services and products;
+- Carry out transactions you have requested;
+- Perform auditing, data analysis, and research;
+- Enforce our [Terms of Service](/legal/terms), our Privacy Policy, and other agreements with you;
+- Prevent illegal activity, protect or enforce our rights, property, or customers, and contact appropriate authorities in accordance with Privacy Laws; and
+- Comply with applicable law (including Privacy Laws), and with subpoenas or other mandatory legal processes.
+
+We will keep User’s Personal Information for as long as necessary to provide them with our Services. We will also keep User Personal’s Information as necessary for backup, archiving, audit, preventing fraud, resolving disputes, and troubleshooting problems. 
+
+## Information shared with third parties
+
+We will not share any Personal Information that we have collected from you, except under these circumstances:
+
+- **Provide the Service:** We may share your Personal Information to third-parties for the sole purpose of providing you with the Services through our Site. For example, we may share data with service providers who host our websites or provide email services on our behalf.
+- **Research and Analysis:** We may share aggregated information and de-identified information with third parties for educational and industry research and analysis, demographic profiling, and other similar purposes.
+- **Information shared with Instructors/Teachers/Course Owners:** if you are a student who joined a course provided by the Service, all Personal Information may be shared with your instructors or educational institution via the functionalities of the Service, or upon request. Note that this includes all your assignments and corresponding scores, as well as IP addresses through which you accessed the Services.
+- **Information disclosed for our protection and the protection of others:** We cooperate with government and law enforcement officials or private parties to enforce and comply with the law. We may disclose any information about you to the government or law enforcement officials or private parties as we, in our sole discretion, believe necessary or appropriate: (i) to respond to claims and, legal process (including subpoenas); (ii) to protect our property, rights and safety and the property, rights, and safety of a third party or the public in general; and (iii) to stop any activity that we consider the illegal, unethical or legally actionable activity.
+
+## Parental or legal guardian access to personal information
+
+If you are a parent or legal guardian of a student user who is under the age of 18, you may wish to request access to your child’s Personal Information. However, because we hold limited information about student users, we will not be able to verify who a particular student is or what your relationship to them is. Therefore, all such requests must be submitted to the educational institution.
+
+## Protecting your data
+
+We strive to keep your personal information safe and secure at all times. Your personal information is processed entirely within the United States, except as detailed below.
+
+FERPA (Family Educational Rights and Privacy Act) requires that reasonable measures be taken to ensure the security of personally identifiable information from student academic records. PrairieLearn, Inc. will make every effort to comply with the FERPA disclosure policies. 
+
+For certain Canadian universities, all personal information collected by or through the Service is stored only in Canada and accessed only in Canada in accordance with the British Columbia Freedom of Information and Protection of Privacy Act (“FIPPA”) section 30.1 except as authorized under FIPPA section 33.1(1)(p), (p.1) and (p.2) or otherwise approved by Customer in writing. For greater clarity, for these Canadian universities, PrairieLearn will comply with all obligations under FIPPA with respect to personal information and all production data centers and disaster recovery sites will reside within Canada.
+
+## What we will not do with your Personal Information
+
+- PrairieLearn does not and will not sell your Personal Information in connection with your use of the Service.
+- PrairieLearn does not and will not use any of your Personal Information to engage in targeted marketing.
+
+## Security of your Personal Information
+
+The security of your Personal Information is important to us, but remember that no method of transmission over the Internet or method of electronic storage is 100% secure. We strive to use commercially acceptable means to protect your Personal Information and continuously audit for security vulnerabilities. Passwords are required to access your Personal Information, and it is your responsibility to keep your password confidential. Even with all the security measurements, we cannot guarantee the absolute protection of your Personal Information from hackers and unauthorized third parties when using public networks. To the fullest extent permitted by applicable law, we do not accept liability for unintentional disclosure.
+
+## Links to other websites
+
+Our Services may contain links to other websites and services. Our Privacy Policy does not apply to such websites or services and we are not responsible for the content, privacy or security practices and policies of those websites or services. To protect your information, we recommend that you carefully review the privacy policies of other websites and services that you access.
+
+## Changes to Personal Information
+
+You may change some of your personal information in your account by editing your profile within the Service. You may also request changes or deletions by emailing us at the email address below. We will respond to your request, when permitted by law, within 30 days. We may be unable to delete information that resides in our archives.
+
+If you are a student, we may be obligated to comply with requests from your instructor, course owner, or educational institution to change or delete the Personal Information associated with your Account. In addition, you may lose access to information from a particular course due to access rules specified by your instructor.
+
+## International Customer Privacy
+
+PrairieLearn is operated in the United States. If you are located outside of the United States, then please be aware that information we collect will be transferred to and processed in the United States. By using our Services, or providing us with any information, you fully understand and unambiguously consent to this transfer, processing and storage of your information in the United States, a jurisdiction in which the privacy laws may not be as comprehensive as those in the country where you are located, reside and/or are a citizen. We ensure that the recipient of your Personal Information offers an adequate level of protection and security, for instance by entering into standard contractual clauses or an alternative mechanism for the transfer of data as approved by the European Commission or other applicable regulators or legislators. 
+
+## Contact Us 
+
+If you have any questions about this Privacy Policy, please contact us at support@prairielearn.com.

--- a/legal/terms.md
+++ b/legal/terms.md
@@ -1,0 +1,111 @@
+Welcome to PrairieLearn! This document explains the terms of service (“Terms”) for using software provided by PrairieLearn, Inc. (the “Service”). When you use the Service, you’re agreeing to all of the terms and conditions on this page. These Terms apply to all visitors, students, teachers, instructors, administrators, and others who access the Service (“Users”).
+
+PrairieLearn is an open-source learning platform. PrairieLearn, Inc. (“we”, “us”, or “our”) is a company created to provide hosting and support for PrairieLearn software at prairielearn.com (the "Site"). These Terms apply only to software hosted by PrairieLearn, Inc. (the “Service”). If you use an instance of PrairieLearn hosted by another individual, company, organization, institution, or party, you will be bound by their terms and conditions, if specified.
+
+## 1.	Use of the Service
+
+Using the Service requires creating an account or signing in with an authentication provider. You’re responsible for all the activity on your account, and for keeping your password confidential and otherwise securing your account. If you find out that someone has used your account without your permissions, you should report it to support@prairielearn.com.
+
+To sign up for an account, you must be at least 18 years old. If you are under 18, you represent that you have your parent or guardian’s permission to use the Service. Please have them read this agreement with you.
+
+If you are a parent or legal guardian of a user under the age of 18, by allowing your child to use the Service, you are subject to the terms of this agreement and responsible for your child’s activity on the Service.
+
+When you use the Service, you agree not to engage in any of the following prohibited activities:
+
+- copying, distributing, or disclosing any part of the Service in any medium, including without limitation by any automated or non-automated “scraping”;
+- using any automated system, including without limitation “robots,” “spiders,” “offline readers,” etc., to access the Service in a manner that sends more requests to the Service than a human can reasonably produce in the same period of time by using a conventional web browser (except that we grant an exception to teachers, instructors, or administrators who may use APIs provided by the service to access assessment scores, submissions, and other content, provided that such use does not impose at our sole discretion an unreasonable or disproportionately large load on our infrastructure);
+- transmitting spam, chain letters, or other unsolicited email;
+- attempting to interfere with, compromise the system integrity or security or decipher any transmissions to or from the servers running the Service;
+- taking any action that imposes, or may impose at our sole discretion an unreasonable or disproportionately large load on our infrastructure;
+- uploading invalid data, viruses, worms, or other software agents through the Service;
+- collecting or harvesting any personally identifiable information, including account names, from the Service;
+- using the Service for any commercial solicitation purposes;
+- impersonating another person or otherwise misrepresenting your affiliation with a person or entity, conducting fraud, hiding or attempting to hide your identity;
+- interfering with the proper working of the Service;
+- accessing any content on the Service through any technology or means other than those provided or authorized by the Service; or
+- bypassing the measures we may use to prevent or restrict access to the Service, including without limitation features that prevent or restrict use or copying of any content or enforce limitations on use of the Service or the content therein.
+
+We may, without prior notice, change the Service; stop providing the Service or features of the Service, to you or to Users generally; or create usage limits for the Service. We may permanently or temporarily terminate or suspend your access to the Service without notice and liability for any reason, including if in our sole determination you violate any provision of these Terms, or for no reason. Upon termination for any reason or no reason, you continue to be bound by these Terms.
+
+## 2.	User Content
+
+Some features of the Service allow Users to create or upload content, such as questions, assessments, configuration code, submissions, question feedback, and other content or information, collectively referred to as “User Content”. “User Content” also includes prompts and feedback that are automatically generated from code provided by Users. We claim no ownership rights over User Content created by you. The User Content you create remains yours; however, by providing or sharing User Content through the Service, you agree to allow others to view, edit, and/or share your User Content in accordance with your settings and these Terms. We have the right (but not the obligation) at our sole discretion to remove any User Content that is shared via the Service.
+
+You agree not to post any User Content that:
+
+- may constitute or contribute to a crime or tort;
+- contains any information or content that we deem to be unlawful, harmful, abusive, racially or ethnically offensive, defamatory, infringing, invasive of personal privacy or publicity rights, harassing, humiliating to other people (publicly or otherwise), libelous, threatening, profane, obscene, or otherwise objectionable; or
+- violates any school or other applicable policy, including those related to cheating or ethics.
+
+You agree that any User Content that you post does not and will not violate third-party rights of any kind, including without limitation any Intellectual Property Rights (as defined below) or rights of privacy. If you are an instructor or teacher, you represent and warrant that you have the right to provide any User Content, including without limitation any questions, assessments, or classroom materials that you provide to the Service. To the extent that your User Content contains music, you hereby represent that you are the owner of all the copyright rights, including without limitation the performance, mechanical, and sound recordings rights, with respect to each and every musical composition (including lyrics) and sound recording contained in such User Content and have the power to grant the license granted below. You understand that publishing your User Content on the Service is not a substitute for registering it with the U.S. Copyright Office, the Writer’s Guild of America, or any other rights organization.
+
+For the purposes of these Terms, “Intellectual Property Rights” means all patent rights, copyright rights, mask work rights, moral rights, rights of publicity, trademark, trade dress and service mark rights, goodwill, trade secret rights and other intellectual property rights as may now exist or hereafter come into existence, and all applications therefore and registrations, renewals and extensions thereof, under the laws of any state, country, territory or other jurisdiction.
+
+In connection with your User Content, you affirm, represent, and warrant the following:
+
+- You have the written consent of each and every identifiable natural person in the User Content, if any, to use such person’s name or likeness in the manner contemplated by the Service and these Terms, and each such person has released you from any liability that may arise in relation to such use.
+- You have obtained and are solely responsible for obtaining all consents as may be required by law to post any User Content relating to third parties.
+- Your User Content and our use thereof as contemplated by these Terms and the Service will not violate any law or infringe any rights of any third party, including but not limited to any Intellectual Property Rights and privacy rights.
+- We may exercise the rights to your User Content granted under these Terms without liability for payment of any guild fees, residuals, payments, fees, or royalties payable under any collective bargaining agreement or otherwise.
+- To the best of your knowledge, all your User Content and other information that you provide to us is truthful and accurate.
+
+We take no responsibility and assume no liability for any User Content that you or any other User or third party posts, sends, or otherwise makes available over the Service. You shall be solely responsible for your User Content and the consequences of posting, publishing it, sharing it, or otherwise making it available on the Service, and you agree that we are only acting as a passive conduit for your online distribution and publication of your User Content. You understand and agree that you may be exposed to User Content that is inaccurate, objectionable, inappropriate for children, or otherwise unsuited to your purpose, and you agree that we shall not be liable for any damages you allege to incur as a result of or relating to any User Content.
+
+## 3.	User Content License Grant
+
+By posting or otherwise making available any User Content on or through the Service, you expressly grant, and you represent and warrant that you have all rights necessary to grant and hereby grant to PrairieLearn, Inc. a royalty-free, sublicensable, transferable, perpetual, irrevocable, non-exclusive, worldwide license, subject to the restrictions set forth below to reproduce, modify, publish, publicly display, make derivative works and otherwise use such User Content and your name, voice, and/or likeness as contained in your User Content, in whole or in part, and in any form, media or technology, whether now known or hereafter developed, for use in connection with the Service and our (and its successors’ and affiliates’) business, including without limitation for promoting and redistributing part or all of the Service (and derivative works thereof) in any media formats and through any media channels. Notwithstanding the foregoing, we will only use your User Content as you provide in your settings page.
+
+If you are a Student, you agree that we may make your User Content available to your Teacher(s) and School(s), for the purposes of improving the Service only and at all times on a confidential basis, may use your Educational Records solely on an aggregated, de-identified basis and will not share such information with third parties.
+
+If you are a Teacher or School, you agree that we may (i) make specific educational records available to the applicable Student, and (ii) for the purposes of improving the Service only and at all times on a confidential basis, otherwise use your educational records on an aggregated, de-identified basis and will not share such information with third parties.
+
+## 4.	User Content License Grant
+Refer to our Privacy Policy (prairielearn.com) for information on how we collect, use and disclose information from our users.
+
+## 5.	Security
+
+We use commercially reasonable and appropriate physical, managerial, and technical safeguards to preserve the integrity and security of your personal information and implement your privacy settings. However, we cannot guarantee that unauthorized third parties will never be able to defeat our security measures or use your personal information for improper purposes. You acknowledge that you provide your personal information at your own risk.
+
+## 6.	Other Websites and Links
+
+User Content and other content on the Service may contain links to other websites. When you access third-party websites, you do so at your own risk. We do not control or endorse these sites. If you access a third-party website or service from the Service or share your User Content on or through any third-party website or service, you do so at your own risk, and you understand that these Terms do not apply to your use of such sites. You expressly relieve us from any and all liability arising from your use of any third-party website, service, or content, including without limitation User Content submitted by other Users.
+
+We partner with Stripe for payment processing. If you are an instructor or administrator signing up for an account to pay for the Service, you are also agreeing to Stripe’s terms of service.
+
+## 7.	Account Termination
+
+You may terminate your account at any time by contacting support@prairielearn.com. We may retain certain information as required by law or contractual obligation, or as necessary for our legitimate business purposes. All provisions of this agreement survive termination of an account.
+
+## 8.	Changes to Terms or Services
+
+We reserve the right to modify the Terms at any time. We will notify you about these changes by posting the modified Terms on the Site. If you continue to use the Services after we post the modified Terms on the Site, you agree to be bound by the modified Terms. It is your responsibility to review these changes when they are posted. If you do not agree to the new Terms, then you may stop using the Service. 
+
+## 9.	Feedback
+
+We welcome your comments, ideas, suggestions, or proposals (“Feedback”) by emailing us at support@prairielearn.com. However, if you submit Feedback to us, then you grant us non-exclusive, worldwide, royalty-free license that is sublicensable and transferable, to use, sell, copy, modify, reproduce, publicly display, distribute, or create derivative works based upon the Feedback in any manner without any obligation, royalty or restriction based on intellectual property rights or otherwise.
+
+## 10.	Indemnity
+
+You agree to defend, indemnify and hold harmless PrairieLearn, Inc. and our officers, directors, employees, partners, contractors, representatives, agents, and third-party providers from and against any and all claims, causes of action, damages, obligations, losses, liabilities, costs or debt, and expenses (including reasonable attorneys' fees and costs) and all amounts paid in settlement arising from or relating to, breach of these terms or violation of any applicable laws. We reserve the right, in our sole discretion and at our own expense, to assume the exclusive defense and control of any matter for which you have agreed to indemnify us and you agree to assist and cooperate with us as reasonably required in the defense or settlement of any such matters.
+
+## 11.	Warranty disclaimer 
+
+THE SERVICE IS PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS. USE OF THE SERVICE IS AT YOUR OWN RISK. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE SERVICE IS PROVIDED WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY YOU FROM IS OR THROUGH THE SERVICE WILL CREATE ANY WARRANTY NOT EXPRESSLY STATED HEREIN. WITHOUT LIMITING THE FOREGOING, PRAIRIELEARN, OUR AFFILIATES, AND OUR LICENSORS DO NOT WARRANT THAT THE CONTENT IS ACCURATE, RELIABLE OR CORRECT; THAT THE SERVICE WILL MEET YOUR REQUIREMENTS; THAT THE SERVICE WILL BE AVAILABLE AT ANY PARTICULAR TIME OR LOCATION, UNINTERRUPTED OR SECURE; THAT ANY DEFECTS OR ERRORS WILL BE CORRECTED; OR THAT THE SERVICE IS FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. ANY CONTENT DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SERVICE IS DOWNLOADED AT YOUR OWN RISK AND YOU WILL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR MOBILE DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH DOWNLOAD OR YOUR USE OF THE SERVICE.
+
+WE DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED BY A THIRD PARTY THROUGH THE SERVICE OR ANY HYPERLINKED WEBSITE OR SERVICE, AND WE WILL NOT BE A PARTY TO OR IN ANY WAY MONITOR ANY TRANSACTION BETWEEN YOU AND THIRD-PARTY PROVIDERS OF PRODUCTS OR SERVICES.
+
+FEDERAL LAW, SOME STATES, PROVINCES AND OTHER JURISDICTIONS DO NOT ALLOW THE EXCLUSION AND LIMITATIONS OF CERTAIN IMPLIED WARRANTIES, SO THE ABOVE EXCLUSIONS MAY NOT APPLY TO YOU. THESE TERMS GIVES YOU SPECIFIC LEGAL RIGHTS, AND YOU MAY ALSO HAVE OTHER RIGHTS WHICH VARY FROM STATE TO STATE. THE DISCLAIMERS AND EXCLUSIONS UNDER THESE TERMS WILL NOT APPLY TO THE EXTENT PROHIBITED BY APPLICABLE LAW.
+  
+## 12.	Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL WE, OUR AFFILIATES, AGENTS, DIRECTORS, EMPLOYEES, SUPPLIERS OR LICENSORS BE LIABLE FOR ANY INDIRECT, PUNITIVE, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES, INCLUDING WITHOUT LIMITATION DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES, ARISING OUT OF OR RELATING TO THE USE OF, OR INABILITY TO USE, THE SERVICE. UNDER NO CIRCUMSTANCES WILL WE BE RESPONSIBLE FOR ANY DAMAGE, LOSS OR INJURY RESULTING FROM HACKING, TAMPERING OR OTHER UNAUTHORIZED ACCESS OR USE OF THE SERVICE OR YOUR ACCOUNT OR THE INFORMATION CONTAINED THEREIN.
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, WE ASSUME NO LIABILITY OR RESPONSIBILITY FOR ANY (I) ERRORS, MISTAKES, OR INACCURACIES OF CONTENT; (II) PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO OR USE OF OUR SERVICE; (III) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SECURE SERVERS AND/OR ANY AND ALL PERSONAL INFORMATION STORED THEREIN; (IV) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICE; (V) ANY BUGS, VIRUSES, TROJAN HORSES, OR THE LIKE THAT MAY BE TRANSMITTED TO OR THROUGH OUR SERVICE BY ANY THIRD PARTY; (VI) ANY ERRORS OR OMISSIONS IN ANY CONTENT OR FOR ANY LOSS OR DAMAGE INCURRED AS A RESULT OF THE USE OF ANY CONTENT POSTED, EMAILED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE THROUGH THE SERVICE; AND/OR (VII) USER CONTENT OR THE DEFAMATORY, OFFENSIVE, OR ILLEGAL CONDUCT OF ANY THIRD PARTY. IN NO EVENT SHALL WE, OUR AFFILIATES, AGENTS, DIRECTORS, EMPLOYEES, SUPPLIERS, OR LICENSORS BE LIABLE TO YOU FOR ANY CLAIMS, PROCEEDINGS, LIABILITIES, OBLIGATIONS, DAMAGES, LOSSES OR COSTS IN AN AMOUNT EXCEEDING THE AMOUNT YOU PAID TO PRAIRIELEARN, INC. UNDER THIS AGREEMENT DURING THE TWELVE (12) MONTHS IMMEDIATELY PRECEDING THE EVENT GIVEN RISE TO LIABILITY, OR $100.00, WHICHEVER IS GREATER.
+
+THIS LIMITATION OF LIABILITY SECTION APPLIES WHETHER THE ALLEGED LIABILITY IS BASED ON CONTRACT, TORT, NEGLIGENCE, STRICT LIABILITY, OR ANY OTHER BASIS, EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THE FOREGOING LIMITATION OF LIABILITY SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW IN THE APPLICABLE JURISDICTION.
+
+SOME STATES DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATIONS OR EXCLUSIONS MAY NOT APPLY TO YOU. THESE TERMS GIVES YOU SPECIFIC LEGAL RIGHTS, AND YOU MAY ALSO HAVE OTHER RIGHTS WHICH VARY FROM STATE TO STATE. THE DISCLAIMERS, EXCLUSIONS, AND LIMITATIONS OF LIABILITY UNDER THESE TERMS WILL NOT APPLY TO THE EXTENT PROHIBITED BY APPLICABLE LAW.
+
+## 13.	Contact
+
+If you have any questions about these Terms of Service, please contact us at support@prairielearn.com

--- a/legal/terms.md
+++ b/legal/terms.md
@@ -1,6 +1,10 @@
+---
+title: Terms of Service
+--- 
+
 Welcome to PrairieLearn! This document explains the terms of service (“Terms”) for using software provided by PrairieLearn, Inc. (the “Service”). When you use the Service, you’re agreeing to all of the terms and conditions on this page. These Terms apply to all visitors, students, teachers, instructors, administrators, and others who access the Service (“Users”).
 
-PrairieLearn is an open-source learning platform. PrairieLearn, Inc. (“we”, “us”, or “our”) is a company created to provide hosting and support for PrairieLearn software at prairielearn.com (the "Site"). These Terms apply only to software hosted by PrairieLearn, Inc. (the “Service”). If you use an instance of PrairieLearn hosted by another individual, company, organization, institution, or party, you will be bound by their terms and conditions, if specified.
+PrairieLearn is an open-source learning platform. PrairieLearn, Inc. (“we”, “us”, or “our”) is a company created to provide hosting and support for PrairieLearn software at [prairielearn.com](/) (the "Site"). These Terms apply only to software hosted by PrairieLearn, Inc. (the “Service”). If you use an instance of PrairieLearn hosted by another individual, company, organization, institution, or party, you will be bound by their terms and conditions, if specified.
 
 ## 1.	Use of the Service
 
@@ -60,7 +64,7 @@ If you are a Student, you agree that we may make your User Content available to 
 If you are a Teacher or School, you agree that we may (i) make specific educational records available to the applicable Student, and (ii) for the purposes of improving the Service only and at all times on a confidential basis, otherwise use your educational records on an aggregated, de-identified basis and will not share such information with third parties.
 
 ## 4.	User Content License Grant
-Refer to our Privacy Policy (prairielearn.com) for information on how we collect, use and disclose information from our users.
+Refer to our [Privacy Policy](/legal/privacy) for information on how we collect, use and disclose information from our users.
 
 ## 5.	Security
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,11 +7,9 @@ interface FooterLinkProps {
 
 const FooterLink: React.FC<FooterLinkProps> = ({ href, children }) => {
   return (
-    <p className="my-0">
-      <a href={href} className="link-secondary text-decoration-none">
-        {children}
-      </a>
-    </p>
+    <a href={href} className="link-secondary text-decoration-none">
+      {children}
+    </a>
   );
 };
 
@@ -20,27 +18,47 @@ export const Footer: React.FC = () => {
     <footer className="bg-light pt-4">
       <div className="container-md">
         <div className="row">
-          <div className="col-12 col-sm-6 col-md-4 mb-4">
+          <div className="col-6 col-sm-4 mb-3">
             <h6 className="text-uppercase text-secondary fw-bold">Resources</h6>
-            <FooterLink href="https://prairielearn.readthedocs.io/en/latest/">
-              Documentation
-            </FooterLink>
-            <FooterLink href="https://github.com/PrairieLearn/PrairieLearn">
-              GitHub
-            </FooterLink>
-            <FooterLink href="/research">Research</FooterLink>
-            <FooterLink href="/pricing">Pricing</FooterLink>
+            <ul className="list-unstyled">
+              <li className="mb-2">
+                <FooterLink href="https://prairielearn.readthedocs.io/en/latest/">
+                  Documentation
+                </FooterLink>
+              </li>
+              <li className="mb-2">
+                <FooterLink href="https://github.com/PrairieLearn/PrairieLearn">
+                  GitHub
+                </FooterLink>
+              </li>
+              <li className="mb-2">
+                <FooterLink href="/research">Research</FooterLink>
+              </li>
+              <li className="mb-2">
+                <FooterLink href="/pricing">Pricing</FooterLink>
+              </li>
+            </ul>
           </div>
-          <div className="col-12 col-sm-6 col-md-4 mb-4">
+          <div className="col-6 col-sm-4 mb-3">
             <h6 className="text-uppercase text-secondary fw-bold">Legal</h6>
-            <FooterLink href="/legal/terms">Terms of Service</FooterLink>
-            <FooterLink href="/legal/privacy">Privacy Policy</FooterLink>
+            <ul className="list-unstyled">
+              <li className="mb-2">
+                <FooterLink href="/legal/terms">Terms of Service</FooterLink>
+              </li>
+              <li className="mb-2">
+                <FooterLink href="/legal/privacy">Privacy Policy</FooterLink>
+              </li>
+            </ul>
           </div>
-          <div className="col-12 col-sm-6 col-md-4 mb-4">
+          <div className="col-6 col-sm-4 mb-3">
             <h6 className="text-uppercase text-secondary fw-bold">Contact</h6>
-            <FooterLink href="mailto:hello@prairielearn.com">
-              hello@prairielearn.com
-            </FooterLink>
+            <ul className="list-unstyled">
+              <li className="mb-2">
+                <FooterLink href="mailto:hello@prairielearn.com">
+                  hello@prairielearn.com
+                </FooterLink>
+              </li>
+            </ul>
           </div>
         </div>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+interface FooterLinkProps {
+  href: string;
+  children: React.ReactNode;
+}
+
+const FooterLink: React.FC<FooterLinkProps> = ({ href, children }) => {
+  return (
+    <p className="my-0">
+      <a href={href} className="link-secondary text-decoration-none">
+        {children}
+      </a>
+    </p>
+  );
+};
+
+export const Footer: React.FC = () => {
+  return (
+    <footer className="bg-light pt-4">
+      <div className="container-md">
+        <div className="row">
+          <div className="col-12 col-sm-6 col-md-4 mb-4">
+            <h6 className="text-uppercase text-secondary fw-bold">Resources</h6>
+            <FooterLink href="https://prairielearn.readthedocs.io/en/latest/">
+              Documentation
+            </FooterLink>
+            <FooterLink href="https://github.com/PrairieLearn/PrairieLearn">
+              GitHub
+            </FooterLink>
+            <FooterLink href="/research">Research</FooterLink>
+            <FooterLink href="/pricing">Pricing</FooterLink>
+          </div>
+          <div className="col-12 col-sm-6 col-md-4 mb-4">
+            <h6 className="text-uppercase text-secondary fw-bold">Legal</h6>
+            <FooterLink href="/legal/terms">Terms of Service</FooterLink>
+            <FooterLink href="/legal/privacy">Privacy Policy</FooterLink>
+          </div>
+          <div className="col-12 col-sm-6 col-md-4 mb-4">
+            <h6 className="text-uppercase text-secondary fw-bold">Contact</h6>
+            <FooterLink href="mailto:hello@prairielearn.com">
+              hello@prairielearn.com
+            </FooterLink>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 
 import "../styles/bootstrap.scss";
 import { Header } from "../components/Header";
+import { Footer } from "../components/Footer";
 import * as gtag from "../lib/gtag";
 
 const MyApp: React.FC<AppProps> = ({ Component, pageProps }) => {
@@ -23,6 +24,7 @@ const MyApp: React.FC<AppProps> = ({ Component, pageProps }) => {
     <React.Fragment>
       <Header />
       <Component {...pageProps} />
+      <Footer />
     </React.Fragment>
   );
 };

--- a/src/pages/legal/[slug].tsx
+++ b/src/pages/legal/[slug].tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { GetStaticPaths, GetStaticProps } from "next";
+import Head from "next/head";
+import { serialize } from "next-mdx-remote/serialize";
+import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
+import fs from "fs-extra";
+
+import { PageBanner } from "../../components/Banner";
+import path from "path";
+
+interface TermsProps {
+  source: MDXRemoteSerializeResult;
+}
+
+const Terms: React.FC<TermsProps> = ({ source }) => {
+  return (
+    <React.Fragment>
+      <Head>
+        <title>Terms of Service | PrairieLearn</title>
+      </Head>
+
+      <PageBanner title="Terms of Service" />
+
+      <div className="container my-5">
+        <MDXRemote {...source} />
+      </div>
+    </React.Fragment>
+  );
+};
+
+export default Terms;
+
+interface PathParams {
+  slug: string;
+  [key: string]: any;
+}
+
+export const getStaticPaths: GetStaticPaths<PathParams> = async () => {
+  return {
+    paths: ["terms", "privacy"].map((slug) => ({ params: { slug } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<TermsProps, PathParams> = async ({
+  params,
+}) => {
+  if (!params) throw new Error("Missing params");
+
+  const source = await fs.readFile(
+    path.resolve("legal", `${params.slug}.md`),
+    "utf-8"
+  );
+  return {
+    props: {
+      source: await serialize(source),
+    },
+  };
+};

--- a/src/pages/legal/[slug].tsx
+++ b/src/pages/legal/[slug].tsx
@@ -4,22 +4,24 @@ import Head from "next/head";
 import { serialize } from "next-mdx-remote/serialize";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import fs from "fs-extra";
+import path from "path";
+import matter from "gray-matter";
 
 import { PageBanner } from "../../components/Banner";
-import path from "path";
 
 interface TermsProps {
+  title: string;
   source: MDXRemoteSerializeResult;
 }
 
-const Terms: React.FC<TermsProps> = ({ source }) => {
+const Terms: React.FC<TermsProps> = ({ title, source }) => {
   return (
     <React.Fragment>
       <Head>
-        <title>Terms of Service | PrairieLearn</title>
+        <title>{title} | PrairieLearn</title>
       </Head>
 
-      <PageBanner title="Terms of Service" />
+      <PageBanner title={title} />
 
       <div className="container my-5">
         <MDXRemote {...source} />
@@ -51,9 +53,14 @@ export const getStaticProps: GetStaticProps<TermsProps, PathParams> = async ({
     path.resolve("legal", `${params.slug}.md`),
     "utf-8"
   );
+  const {
+    content,
+    data: { title },
+  } = matter(source);
   return {
     props: {
-      source: await serialize(source),
+      title,
+      source: await serialize(content),
     },
   };
 };


### PR DESCRIPTION
This PR adds pages with the PrairieLearn, Inc. Terms of Service and Privacy Policy. The pages are linked to from a new footer that's present on every page:

<img width="966" alt="Screen Shot 2022-06-03 at 10 26 03" src="https://user-images.githubusercontent.com/1476544/171915372-14812c6d-c388-4527-b8d2-41175e93bf97.png">
