### PR TITLE
Remove Google Analytics

### DIFF
--- a/legal/privacy.md
+++ b/legal/privacy.md
@@ -30,10 +30,6 @@ When a User joins a course on the Services as a student, we get access to their 
 
 Web Cookies are small pieces of data created by web servers and sent to your computer while you are browsing a website. We may use session cookies (which expire once you close your web browser) and persistent cookies (which stay on your computer until you delete them) to provide you with a more personal and interactive experience on our Site. Most web browsers are set to accept cookies by default. You may choose to set your web browser to refuse cookies, or to alert you when cookies are being sent. If you do so, note that some parts of our Site and Services may not function properly. We do not use web beacons or flash cookies.
 
-### Information collected for analytics
-
-We use analytics services from Google Analytics to help analyze how users use the Site. These services use cookies and scripts to collect and store information such as how users interact with our Service, errors users encounter when using our Site and general User statistics. We use this information to improve our Site and Services. We do not tie the information gathered using third party analytics to your personally identifiable information.
-
 ### Other general use of Personal Information
 
 In addition to the specific uses described above, we may also make use of Personal Information for the following purposes: 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "unist-util-visit": "^4.1.0"
   },
   "devDependencies": {
-    "@types/gtag.js": "^0.0.8",
     "@types/node": "^17.0.10",
     "@types/react": "^17.0.38",
     "eslint": "^8.7.0",

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -1,9 +1,0 @@
-export const GA_TRACKING_ID = "G-20ZFCK3V0P";
-
-export const pageview = (url: URL) => {
-  window.gtag("config", GA_TRACKING_ID, { page_path: url });
-};
-
-export const event = (name: string, parameters: Record<string, any>) => {
-  window.gtag("event", name, parameters);
-};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,26 +1,12 @@
 import React from "react";
 import { AppProps } from "next/app";
-import { useRouter } from "next/router";
 import SSRProvider from "react-bootstrap/SSRProvider";
 
 import "../styles/bootstrap.scss";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
-import * as gtag from "../lib/gtag";
 
 const MyApp: React.FC<AppProps> = ({ Component, pageProps }) => {
-  const router = useRouter();
-
-  React.useEffect(() => {
-    const handleRouteChange = (url: URL) => {
-      gtag.pageview(url);
-    };
-    router.events.on("routeChangeComplete", handleRouteChange);
-    return () => {
-      router.events.off("routeChangeComplete", handleRouteChange);
-    };
-  }, [router.events]);
-
   return (
     <React.Fragment>
       <SSRProvider>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,8 +6,6 @@ import Document, {
   DocumentContext,
 } from "next/document";
 
-import { GA_TRACKING_ID } from "../lib/gtag";
-
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
@@ -23,21 +21,6 @@ class MyDocument extends Document {
             href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css"
             integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X"
             crossOrigin="anonymous"
-          />
-          {process.env.NODE_ENV === "production" && (
-            <script
-              async
-              src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
-            />
-          )}
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-          
-gtag('config', 'G-20ZFCK3V0P');`,
-            }}
           />
         </Head>
         <body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,11 +446,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/gtag.js@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.8.tgz#43035ab23a06b3bd0b23968c5c4ef000c597ad8a"
-  integrity sha512-xKDygydxruSUNkVbZWjiEbMijz9+xZCLb2yiTiQT88pm5EhIAUhaCo05IZF1HcQc90u4W7cp+7OZNpcJxpyL5g==
-
 "@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"


### PR DESCRIPTION
I've basically never looked at the Google Analytics dashboard, so I'm going to remove it so that we can simplify our Privacy Policy. The policy mentioned that we use Google Analytics, but this was only ever on the marketing site, never on the PrairieLearn application itself.

If we want analytics in the future, we should use something like https://plausible.io/ that's better at respecting user privacy.