### PR TITLE
Update PrairieLearn hostname to us.prairielearn.com

### DIFF
--- a/src/components/DemoCourse.tsx
+++ b/src/components/DemoCourse.tsx
@@ -25,7 +25,7 @@ export const DemoCourseCTA: React.FC<DemoCourseCTAProps> = ({
       </div>
       <div className="row justify-content-center my-2">
         <div className="col-md-12 text-center">
-          <Link href="https://www.prairielearn.org/pl/course_instance/4970">
+          <Link href="https://us.prairielearn.com/pl/course_instance/4970">
             <a className="btn btn-warning btn-lg">{buttonLabel}</a>
           </Link>
         </div>

--- a/src/pages/gallery/courses/index.tsx
+++ b/src/pages/gallery/courses/index.tsx
@@ -100,7 +100,7 @@ export default function Courses() {
             <CourseCard
               image={tam211}
               title="Statics"
-              href="https://www.prairielearn.org/pl/course_instance/129328"
+              href="https://us.prairielearn.com/pl/course_instance/129328"
               institution="University of Illinois at Urbana-Champaign"
               rubric="TAM 211"
               ownerName="Wayne Chang"
@@ -120,7 +120,7 @@ export default function Courses() {
             <CourseCard
               image={tam212}
               title="Introductory Dynamics"
-              href="https://www.prairielearn.org/pl/course_instance/129330"
+              href="https://us.prairielearn.com/pl/course_instance/129330"
               institution="University of Illinois at Urbana-Champaign"
               rubric="TAM 212"
               ownerName="Matthew West"
@@ -137,7 +137,7 @@ export default function Courses() {
             <CourseCard
               image={tam251}
               title="Introductory Solid Mechanics"
-              href="https://www.prairielearn.org/pl/course_instance/129329"
+              href="https://us.prairielearn.com/pl/course_instance/129329"
               institution="University of Illinois at Urbana-Champaign"
               rubric="TAM 251"
               ownerName="Mariana Silva"
@@ -157,7 +157,7 @@ export default function Courses() {
             <CourseCard
               image={cs357}
               title="Numerical Methods"
-              href="https://www.prairielearn.org/pl/course_instance/128953"
+              href="https://us.prairielearn.com/pl/course_instance/128953"
               institution="University of Illinois at Urbana-Champaign"
               rubric="CS 357"
               ownerName="Mariana Silva"
@@ -177,7 +177,7 @@ export default function Courses() {
             <CourseCard
               image={cs233Image}
               title="Computer Architecture"
-              href="https://www.prairielearn.org/pl/course_instance/128979"
+              href="https://us.prairielearn.com/pl/course_instance/128979"
               institution="University of Illinois Urbana-Champaign"
               rubric="CS 233"
               ownerName="Geoffrey Herman"
@@ -234,7 +234,7 @@ export default function Courses() {
             <CourseCard
               image={ece6353fraida}
               title="Internet Architecture and Protocols"
-              href="https://www.prairielearn.org/pl/course_instance/129160"
+              href="https://us.prairielearn.com/pl/course_instance/129160"
               institution="New York University"
               rubric="ECE 6353"
               ownerName="Fraida Fund"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -76,7 +76,7 @@ export default function Home() {
                 The best platform for online assessments
               </p>
               <a
-                href="https://www.prairielearn.org/pl/request_course"
+                href="https://us.prairielearn.com/pl/request_course"
                 className="btn btn-light btn-lg me-3 mt-3"
               >
                 Request a course


### PR DESCRIPTION
This is necessary cleanup after we moved from `.org` to `.com` domains.

Once https://github.com/PrairieLearn/PrairieLearn/pull/6976 is merged, we should update the PrairieLearn submodule to pull in `docs.md` changes.

Closes https://github.com/PrairieLearnInc/sysconf/issues/695