### PR TITLE
Rename ToS Section 4 heading to "Privacy Policy"

### DIFF
--- a/src/pages/legal/terms.mdx
+++ b/src/pages/legal/terms.mdx
@@ -65,7 +65,7 @@ If you are a Student, you agree that we may (i) make your User Content available
 
 If you are a Teacher or School, you agree that we may (i) make specific educational records available to the applicable Student, and (ii) for the purposes of improving the Service only and at all times on a confidential basis, otherwise use your educational records on an aggregated, de-identified basis and will not share such information with third parties.
 
-## 4. User Content License Grant
+## 4. Privacy Policy
 
 Refer to our [Privacy Policy](/legal/privacy) for information on how we collect, use and disclose information from our users.
 


### PR DESCRIPTION
The Section 4 heading was identical to that of Section 3 and also didn't seem quite appropriate.