### PR TITLE
Remove options to log in to ca.prairielearn.com

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -93,19 +93,12 @@ export const Header: React.FC = () => {
           >
             Free sign up
           </button>
-          <DropdownButton
-            id="login-dropdown-desktop"
-            title="Login"
-            variant="light"
-            className="d-inline-block"
+          <a
+            href="https://us.prairielearn.com/pl/login"
+            className="btn btn-light btn-md me-3"
           >
-            <Dropdown.Item href="https://us.prairielearn.com/pl/login">
-              Main <span className="text-muted">(us.prairielearn.com)</span>
-            </Dropdown.Item>
-            <Dropdown.Item href="https://ca.prairielearn.com/pl/login">
-              Canada <span className="text-muted">(ca.prairielearn.com)</span>
-            </Dropdown.Item>
-          </DropdownButton>
+            Login
+          </a>
         </div>
       </div>
       <RequestCourseModal

--- a/src/components/RequestCourseModal.tsx
+++ b/src/components/RequestCourseModal.tsx
@@ -6,11 +6,6 @@ import Link from "next/link";
 interface RequestCourseModal extends Pick<ModalProps, "show" | "onHide"> {}
 
 export const RequestCourseModal: React.FC<RequestCourseModal> = (props) => {
-  const [server, setServer] = React.useState<"us" | "ca">("us");
-  const url =
-    server === "ca"
-      ? "https://ca.prairielearn.com/pl/request_course"
-      : "https://us.prairielearn.com/pl/request_course";
   return (
     <Modal {...props} centered aria-labelledby="request-course-modal-title">
       <Modal.Header closeButton>
@@ -23,40 +18,17 @@ export const RequestCourseModal: React.FC<RequestCourseModal> = (props) => {
           Click below to request a course. You&apos;ll be asked to sign in to
           PrairieLearn, after which you can submit your course details.
         </p>
-        <Form className="mb-3">
-          <Form.Check
-            type="radio"
-            name="server"
-            id="server-us"
-            checked={server === "us"}
-            onChange={(e) => setServer("us")}
-            label={
-              <React.Fragment>
-                Main <span className="text-muted">(us.prairielearn.com)</span>
-              </React.Fragment>
-            }
-          />
-          <Form.Check
-            type="radio"
-            name="server"
-            id="server-ca"
-            checked={server === "ca"}
-            onChange={(e) => setServer("ca")}
-            label={
-              <React.Fragment>
-                Canada <span className="text-muted">(ca.prairielearn.com)</span>
-              </React.Fragment>
-            }
-          />
-        </Form>
         <p>
-          <a href={url} className="btn btn-primary">
+          <a
+            href="https://us.prairielearn.com/pl/request_course"
+            className="btn btn-primary"
+          >
             Request a course
           </a>
         </p>
         <p className="mb-0">
-          Have any questions? Use the <Link href="/support">Contact us</Link>{" "}
-          form and we will get back to you soon.
+          Have any questions? <Link href="/support">Contact us</Link> and we
+          will get back to you soon!
         </p>
       </Modal.Body>
     </Modal>


### PR DESCRIPTION
We're in the process of deprecating `ca.prairielearn.com`. We're dropping the login links to make it harder for people to discover it.

After this PR, there will be one more reference to CA remaining on the subprocessors page. I'm leaving that there now, I think for legal reasons we want it there until all CA infra and data has been destroyed.