### PR TITLE
Remove Canada from Amazon Web Services contries

### DIFF
--- a/src/pages/legal/subprocessors.mdx
+++ b/src/pages/legal/subprocessors.mdx
@@ -11,7 +11,7 @@ PrairieLearn, Inc. ("PrairieLearn") uses certain third party sub-processors to a
 | Name                | Purpose                                | Entity Country |
 | ------------------- | -------------------------------------- | -------------- |
 | Airtable            | Customer Relationship Management (CRM) | US             |
-| Amazon Web Services | Cloud service provider                 | US / Canada    |
+| Amazon Web Services | Cloud service provider                 | US             |
 | Google Workspaces   | Customer communication and support     | US             |
 | Honeycomb           | Monitoring                             | US             |
 | OpenAI              | AI assistance for user tasks           | US             |


### PR DESCRIPTION
# Description

We no longer host any of our services in Canada.

# Testing

N/A
