### PR TITLE
Remove Airtable from list of subprocessors

### DIFF
--- a/src/pages/legal/subprocessors.mdx
+++ b/src/pages/legal/subprocessors.mdx
@@ -8,17 +8,17 @@ PrairieLearn, Inc. ("PrairieLearn") uses certain third party sub-processors to a
 
 ## List of sub-processors
 
-| Name                | Purpose                                | Entity Country |
-| ------------------- | -------------------------------------- | -------------- |
-| Amazon Web Services | Cloud service provider                 | US             |
-| Anthropic           | AI assistance for user tasks           | US             |
-| Google Workspaces   | Customer communication and support     | US             |
-| Google Gemini       | AI assistance for user tasks           | US             |
-| Honeycomb           | Monitoring                             | US             |
-| OpenAI              | AI assistance for user tasks           | US             |
-| Sentry              | Monitoring                             | US             |
-| Slack               | Customer communication and support     | US             |
-| Zoho                | CRM and customer support               | US             |
+| Name                | Purpose                            | Entity Country |
+| ------------------- | ---------------------------------- | -------------- |
+| Amazon Web Services | Cloud service provider             | US             |
+| Anthropic           | AI assistance for user tasks       | US             |
+| Google Workspaces   | Customer communication and support | US             |
+| Google Gemini       | AI assistance for user tasks       | US             |
+| Honeycomb           | Monitoring                         | US             |
+| OpenAI              | AI assistance for user tasks       | US             |
+| Sentry              | Monitoring                         | US             |
+| Slack               | Customer communication and support | US             |
+| Zoho                | CRM and customer support           | US             |
 
 export default ({ children }) => (
   <MarkdownLayout meta={meta}>{children}</MarkdownLayout>

--- a/src/pages/legal/subprocessors.mdx
+++ b/src/pages/legal/subprocessors.mdx
@@ -10,7 +10,6 @@ PrairieLearn, Inc. ("PrairieLearn") uses certain third party sub-processors to a
 
 | Name                | Purpose                                | Entity Country |
 | ------------------- | -------------------------------------- | -------------- |
-| Airtable            | Customer Relationship Management (CRM) | US             |
 | Amazon Web Services | Cloud service provider                 | US             |
 | Anthropic           | AI assistance for user tasks           | US             |
 | Google Workspaces   | Customer communication and support     | US             |


### PR DESCRIPTION
# Description

We no longer use Airtable.

# Testing

N/A
