### PR TITLE
Fix typo in Google Workspace subprocessor name

### DIFF
--- a/src/pages/legal/subprocessors.mdx
+++ b/src/pages/legal/subprocessors.mdx
@@ -13,7 +13,7 @@ PrairieLearn, Inc. ("PrairieLearn") uses certain third party sub-processors to a
 | Amazon Web Services | Cloud service provider             | US             |
 | Anthropic           | AI assistance for user tasks       | US             |
 | Fireflies           | Customer communication and support | US             |
-| Google Workspaces   | Customer communication and support | US             |
+| Google Workspace    | Customer communication and support | US             |
 | Google Gemini       | AI assistance for user tasks       | US             |
 | Honeycomb           | Monitoring                         | US             |
 | Notion              | Customer communication and support | US             |


### PR DESCRIPTION
# Description

It's singular: https://workspace.google.com/

# Testing

N/A