### PR TITLE
Clarify that student submissions are not used for model training

### DIFF
--- a/src/pages/about/blog/introducing-ai-grading/index.mdx
+++ b/src/pages/about/blog/introducing-ai-grading/index.mdx
@@ -40,7 +40,7 @@ export const meta = {
 
 AI grading evaluates open-ended submissions, typed or handwritten, and scores them against your rubric in seconds. Grading hundreds of submissions now takes a single click, and it's available to all PrairieLearn instructors today.
 
-AI grading is opt-in and transparent. AI grading decisions come with detailed explanations and are clearly distinguished from human grades. Course staff remain the final decision-makers on student grading.
+AI grading is opt-in and transparent. AI grading decisions come with detailed explanations and are clearly distinguished from human grades. Course staff remain the final decision-makers on student grading. Student submissions are never used to train AI models when using PrairieLearn AI grading credits.
 
 <BlogCalloutBox variant="tip">
   <div className="fw-bold text-success mb-3">Want to try it now?</div>
@@ -223,8 +223,6 @@ Real numbers from two PrairieLearn courses, measured end-to-end from clicking **
 ### Direction and interpretability at every step
 
 Every grade comes with a detailed explanation of the model's reasoning and its transcription of image submissions — so you can audit decisions, spot edge cases, and trust the results. AI grading works best as a fast first pass, with human review reserved for the cases that need it. Instructor-assigned grades always take precedence.
-
-Submissions are never used to train models, and student identifying information is never shared with LLMs.
 
 To adjust grading behavior, update the rubric instructions — the model follows them.
 

--- a/src/pages/about/blog/introducing-ai-grading/index.mdx
+++ b/src/pages/about/blog/introducing-ai-grading/index.mdx
@@ -40,7 +40,7 @@ export const meta = {
 
 AI grading evaluates open-ended submissions, typed or handwritten, and scores them against your rubric in seconds. Grading hundreds of submissions now takes a single click, and it's available to all PrairieLearn instructors today.
 
-AI grading is opt-in and transparent. AI grading decisions come with detailed explanations and are clearly distinguished from human grades. Course staff remain the final decision-makers on student grading. Student submissions are never used to train AI models.
+AI grading is opt-in and transparent. AI grading decisions come with detailed explanations and are clearly distinguished from human grades. Course staff remain the final decision-makers on student grading.
 
 <BlogCalloutBox variant="tip">
   <div className="fw-bold text-success mb-3">Want to try it now?</div>
@@ -224,7 +224,10 @@ Real numbers from two PrairieLearn courses, measured end-to-end from clicking **
 
 Every grade comes with a detailed explanation of the model's reasoning and its transcription of image submissions — so you can audit decisions, spot edge cases, and trust the results. AI grading works best as a fast first pass, with human review reserved for the cases that need it. Instructor-assigned grades always take precedence.
 
+Submissions are never used to train models, and student identifying information is never shared with LLMs.
+
 To adjust grading behavior, update the rubric instructions — the model follows them.
+
 
 <BlogImage
   src={submissionAndGrading}

--- a/src/pages/about/blog/introducing-ai-grading/index.mdx
+++ b/src/pages/about/blog/introducing-ai-grading/index.mdx
@@ -40,7 +40,7 @@ export const meta = {
 
 AI grading evaluates open-ended submissions, typed or handwritten, and scores them against your rubric in seconds. Grading hundreds of submissions now takes a single click, and it's available to all PrairieLearn instructors today.
 
-AI grading is opt-in and transparent. AI grading decisions come with detailed explanations and are clearly distinguished from human grades. Course staff remain the final decision-makers on student grading.
+AI grading is opt-in and transparent. AI grading decisions come with detailed explanations and are clearly distinguished from human grades. Course staff remain the final decision-makers on student grading. Student submissions are never used to train AI models.
 
 <BlogCalloutBox variant="tip">
   <div className="fw-bold text-success mb-3">Want to try it now?</div>

--- a/src/pages/about/blog/introducing-ai-grading/index.mdx
+++ b/src/pages/about/blog/introducing-ai-grading/index.mdx
@@ -226,7 +226,6 @@ Every grade comes with a detailed explanation of the model's reasoning and its t
 
 To adjust grading behavior, update the rubric instructions — the model follows them.
 
-
 <BlogImage
   src={submissionAndGrading}
   alt="A handwritten student submission alongside the AI's rubric-item selections"


### PR DESCRIPTION
# Description

Adds a sentence to the AI grading blog post's transparency paragraph clarifying that student submissions are never used to train AI models. AI-assisted: full implementation.

# Testing

- Rendered the blog post locally and confirmed the new sentence appears in the second paragraph of the introduction.