### PR TITLE
Validate blog tag casing

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,10 +1,19 @@
 import { parseISO } from "date-fns";
 
+const BLOG_TAGS = [
+  "CBTF",
+  "Case Study",
+  "Development",
+  "Release",
+  "Technical",
+] as const;
+
 export interface BlogPost {
   title: string;
   date: string;
   author: string;
   excerpt?: string;
+  summary?: string;
   tags?: string[];
 }
 
@@ -20,6 +29,36 @@ const BLOG_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
   // Revisit if we ever display times along with dates.
   timeZone: "America/Chicago",
 });
+
+export function validateBlogPostTags(
+  tags: string[] | undefined,
+  source: string,
+): string[] | undefined {
+  if (!tags) {
+    return undefined;
+  }
+
+  return tags.map((tag) => {
+    const normalizedTag = tag.trim().toLocaleLowerCase("en-US");
+    const canonicalTag = BLOG_TAGS.find(
+      (blogTag) => blogTag.toLocaleLowerCase("en-US") === normalizedTag,
+    );
+
+    if (!canonicalTag) {
+      throw new Error(
+        `${source}: unknown blog tag "${tag}". Add it to BLOG_TAGS in src/lib/blog.ts before using it.`,
+      );
+    }
+
+    if (tag !== canonicalTag) {
+      throw new Error(
+        `${source}: use "${canonicalTag}" instead of "${tag}" for blog tag casing.`,
+      );
+    }
+
+    return canonicalTag;
+  });
+}
 
 export function formatBlogDate(date: string): string {
   return BLOG_DATE_FORMATTER.format(parseISO(date));

--- a/src/pages/about/blog/document-cameras/index.mdx
+++ b/src/pages/about/blog/document-cameras/index.mdx
@@ -19,7 +19,7 @@ export const meta = {
   title: "Document cameras make CBTF exams more flexible",
   date: "2026-04-21T00:00:00-05:00",
   author: "Jim Sosnowski",
-  tags: ["CBTF", "Case study"],
+  tags: ["CBTF", "Case Study"],
   summary:
     "Lessons from the UIUC pilot of document cameras in a Computer-Based Testing Facility.",
 };

--- a/src/pages/about/blog/index.tsx
+++ b/src/pages/about/blog/index.tsx
@@ -9,7 +9,12 @@ import { PageBanner } from "../../../components/Banner";
 import { Heading } from "../../../components/Heading";
 import Stack from "../../../components/Stack";
 import { TagList } from "../../../components/Tag";
-import { BlogPost, BlogPostWithSlug, formatBlogDate } from "../../../lib/blog";
+import {
+  BlogPost,
+  BlogPostWithSlug,
+  formatBlogDate,
+  validateBlogPostTags,
+} from "../../../lib/blog";
 import { generateRssFeed } from "../../../lib/rss";
 
 import styles from "./index.module.scss";
@@ -100,7 +105,17 @@ async function getAllPosts(): Promise<BlogPostWithSlug[]> {
       const { meta } = (await import(`./${slug}/index.mdx`)) as {
         meta: BlogPost;
       };
-      return { slug, ...meta };
+      const tags = validateBlogPostTags(meta.tags, `Blog post "${slug}"`);
+
+      return {
+        slug,
+        title: meta.title,
+        date: meta.date,
+        author: meta.author,
+        ...(meta.excerpt !== undefined ? { excerpt: meta.excerpt } : {}),
+        ...(meta.summary !== undefined ? { summary: meta.summary } : {}),
+        ...(tags !== undefined ? { tags } : {}),
+      };
     }),
   );
 

--- a/src/pages/about/blog/introducing-ai-grading/index.mdx
+++ b/src/pages/about/blog/introducing-ai-grading/index.mdx
@@ -15,7 +15,7 @@ export const meta = {
   title: "Introducing AI grading",
   date: "2026-05-21T13:32:00-05:00",
   author: "Miguel Aenlle",
-  tags: ["RELEASE"],
+  tags: ["Release"],
 };
 
 <div


### PR DESCRIPTION
# Description

Standardizes existing blog tag casing and adds a small build-time validation step when MDX blog metadata is loaded for the blog index/RSS. This keeps MDX tags as plain strings while failing the build on unknown tags or casing mismatches, and avoids spreading layout-only metadata into listing props. Majority of implementation was AI-assisted.

# Testing

- `yarn lint`
- `yarn build`
