### PR TITLE
Fix access control blog docs link

### DIFF
--- a/src/pages/about/blog/assessment-access-control/index.mdx
+++ b/src/pages/about/blog/assessment-access-control/index.mdx
@@ -84,7 +84,7 @@ Access rules using the `uids` array don't have a direct JSON equivalent, as stud
 
 ## JSON is still there when you need it
 
-The new UI on the "Access" tab makes it easy to configure assessment access. However, the file-backed parts of the configuration are still available through the new `accessControl` property in `infoAssessment.json` files, which supports advanced use cases like programmatic creation or editing of assessments. Student-label overrides live there too, while student-specific overrides are managed through the UI. The JSON format is described in the [access control documentation](https://docs.prairielearn.com/assessment/accessControlModern/#advanced-json-configuration).
+The new UI on the "Access" tab makes it easy to configure assessment access. However, the file-backed parts of the configuration are still available through the new `accessControl` property in `infoAssessment.json` files, which supports advanced use cases like programmatic creation or editing of assessments. Student-label overrides live there too, while student-specific overrides are managed through the UI. The JSON format is described in the [access control documentation](https://docs.prairielearn.com/assessment/accessControl/#advanced-json-configuration).
 
 export default ({ children }) => (
   <BlogMarkdownLayout meta={meta}>{children}</BlogMarkdownLayout>


### PR DESCRIPTION
# Description

Updates the access control blog post to point the advanced JSON configuration docs link at the current `assessment/accessControl/` page instead of the removed `assessment/accessControlModern/` page.

# Testing

Link is now correct.