### PR TITLE
QTI blog post: use GMT-4 for post timing

### DIFF
--- a/src/pages/about/blog/qti-content-importing/index.mdx
+++ b/src/pages/about/blog/qti-content-importing/index.mdx
@@ -10,7 +10,7 @@ import assessmentsPageImport from "./assessments-page-import.png";
 
 export const meta = {
   title: "Introducing Canvas (QTI) content importing",
-  date: "2026-06-17T12:00:00-05:00",
+  date: "2026-06-17T12:26:00-04:00",
   author: "Austin Billings",
   tags: ["Release"],
 };


### PR DESCRIPTION
# Description

I mistakenly used GMT-5 tz for the post timestamp. This changes it to -4, with more specific minutes.

# Testing

Observe correct timestamp on post.