### PR TITLE
Fix support get started link

### DIFF
--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -52,7 +52,7 @@ export default function Support() {
             <HelpCard
               title="Get Started"
               icon="bi-rocket-takeoff"
-              href="https://docs.prairielearn.com/getStarted/"
+              href="https://docs.prairielearn.com/getting-started/"
             >
               <p className="mb-0">
                 Simple tutorials to get you ready to create your own content.


### PR DESCRIPTION
# Description

Fixes the Support page's Get Started card so it links to the current PrairieLearn docs Getting started page instead of the old `getStarted` path.

AI assistance was used for the implementation and local validation.

# Testing

Ran `pnpm exec eslint src/pages/support/index.tsx` and `pnpm exec prettier --check src/pages/support/index.tsx`.
