### PR TITLE
Fix: Swap demo course links for new OER elements

### DIFF
--- a/src/pages/catalog/elements/index.tsx
+++ b/src/pages/catalog/elements/index.tsx
@@ -252,7 +252,7 @@ export default function Courses() {
             <SharedElementCard
               image={oerAnalogCircuit}
               title="Analog Circuit"
-              href="https://us.prairielearn.com/pl/course_instance/218512/assessments"
+              href="https://us.prairielearn.com/pl/course_instance/218743/assessment/2694116"
               github="https://github.com/PrairieLearn/pl-oer-element-analogcircuit"
               owner={
                 <span>
@@ -264,7 +264,7 @@ export default function Courses() {
             <SharedElementCard
               image={oerWaveform}
               title="Waveform"
-              href="https://us.prairielearn.com/pl/course_instance/218743/assessment/2694116"
+              href="https://us.prairielearn.com/pl/course_instance/218512/assessment/2693873"
               github="https://github.com/PrairieLearn/pl-oer-element-waveform"
               owner={
                 <span>


### PR DESCRIPTION
# Description

In the previously merged PR, the links to the demos for the new OER elements were swapped (Waveform pointed at Analog Circuit and vice versa). This fixes that issue and also points the one for the Waveform element directly at the demo assignment to match the other elements.

# Testing

Tested new links.
