### PR TITLE
Point all demo buttons to new demo page

### DIFF
--- a/src/pages/products/prairietest/index.tsx
+++ b/src/pages/products/prairietest/index.tsx
@@ -215,7 +215,7 @@ export default function PrairieTest() {
         title="Request a demo!"
         subtitle="Want a one-on-one or a group demo? Book a time with us!"
         buttonLabel="Schedule a demo"
-        href="https://calendly.com/marianapl"
+        href="/demo"
       />
     </React.Fragment>
   );

--- a/src/pages/products/testing-center/index.tsx
+++ b/src/pages/products/testing-center/index.tsx
@@ -56,10 +56,7 @@ export default function TestingCenter() {
                   computer-based exams.
                 </p>
               </div>
-              <LinkButton
-                label="Schedule a consultation"
-                href="/demo"
-              />
+              <LinkButton label="Schedule a consultation" href="/demo" />
             </div>
             <div className="col-md-6 order-md-2 pt-4 text-center">
               <Image

--- a/src/pages/products/testing-center/index.tsx
+++ b/src/pages/products/testing-center/index.tsx
@@ -58,7 +58,7 @@ export default function TestingCenter() {
               </div>
               <LinkButton
                 label="Schedule a consultation"
-                href="https://calendly.com/marianapl"
+                href="/demo"
               />
             </div>
             <div className="col-md-6 order-md-2 pt-4 text-center">
@@ -191,7 +191,7 @@ export default function TestingCenter() {
         title="Need more information?"
         subtitle="If you're interested in building a testing center, we can help!"
         buttonLabel="Schedule a consultation"
-        href="https://calendly.com/marianapl"
+        href="/demo"
       />
     </React.Fragment>
   );


### PR DESCRIPTION
# Description

I found two pages (prairietest and testing-center) that still included my old calendly link. This PR updates these links to redirect to the new demo page.