### PR TITLE
Add Pedagogy tag to Craig Zilles blog post

### DIFF
--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -4,6 +4,7 @@ const BLOG_TAGS = [
   "CBTF",
   "Case Study",
   "Development",
+  "Pedagogy",
   "Release",
   "Technical",
 ] as const;

--- a/src/pages/about/blog/craig-zilles-retakes-at-scale/index.mdx
+++ b/src/pages/about/blog/craig-zilles-retakes-at-scale/index.mdx
@@ -9,9 +9,9 @@ import cbtfImage from "./cbtf-room.jpg";
 
 export const meta = {
   title: "Craig Zilles on retakes at scale",
-  date: "2026-07-01T00:00:00-05:00",
+  date: "2026-07-02T10:00:00-05:00",
   author: "Matt West",
-  tags: ["CBTF"],
+  tags: ["CBTF", "Pedagogy"],
   summary:
     "A new podcast episode connects second-chance testing, PrairieLearn, and computer-based testing facilities.",
 };

--- a/src/pages/about/blog/craig-zilles-retakes-at-scale/index.mdx
+++ b/src/pages/about/blog/craig-zilles-retakes-at-scale/index.mdx
@@ -9,7 +9,7 @@ import cbtfImage from "./cbtf-room.jpg";
 
 export const meta = {
   title: "Craig Zilles on retakes at scale",
-  date: "2026-07-02T10:00:00-05:00",
+  date: "2026-07-02T15:00:00-05:00",
   author: "Matt West",
   tags: ["CBTF", "Pedagogy"],
   summary:


### PR DESCRIPTION
## Summary

Adds the `Pedagogy` tag to the Craig Zilles podcast blog post so it can appear on the PrairieLearn homepage, and updates the post timestamp to July 2, 2026 at 10:00 AM Central Time.

## Validation

- `npm exec --yes pnpm@11.9.0 -- lint`
- `npm exec --yes pnpm@11.9.0 -- build`

The production build passes after initializing the PrairieLearn submodule. It still emits existing Sass deprecation warnings and catalog `__docs` warnings.