### PR TITLE
Use main landmark for page content

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,7 +12,9 @@ const MyApp: React.FC<AppProps> = ({ Component, pageProps }) => {
     <React.Fragment>
       <SSRProvider>
         <Header />
-        <Component {...pageProps} />
+        <main>
+          <Component {...pageProps} />
+        </main>
         <Footer />
       </SSRProvider>
     </React.Fragment>


### PR DESCRIPTION
# Description

Wrap the routed page content in `src/pages/_app.tsx` with a semantic `<main>` element while leaving the shared header and footer outside of it.

This makes the deployed legal pages work better as canonical document sources for tools like Pandoc. Pandoc imports the `<main>` content as the document body, so running `pandoc https://www.prairielearn.com/legal/terms -f html -o terms.docx` no longer includes the site navigation text before the Terms of Service content.

AI assistance: majority of implementation and validation.

# Testing

- `pnpm lint`
- `pnpm build`
- Started the production build locally with `pnpm start -p 30281` and verified `curl -s http://localhost:30281/legal/terms | pandoc -f html -t plain` starts at `Terms of Service` without `Free sign up`, `Login`, or navigation text.
- Generated `/tmp/terms-after.docx` with `pandoc http://localhost:30281/legal/terms -f html -o /tmp/terms-after.docx` and verified the DOCX text starts at `Terms of Service`.

The first build attempt failed because the `PrairieLearn` submodule was uninitialized in this worktree. After `git submodule update --init PrairieLearn`, the build passed.
