### PR TITLE
Update legal pages for PrairieTest

### DIFF
--- a/src/pages/legal/privacy.mdx
+++ b/src/pages/legal/privacy.mdx
@@ -4,19 +4,19 @@ export const meta = {
   title: "Privacy policy",
 };
 
-PrairieLearn is an open-source learning platform. PrairieLearn, Inc. (“we”, “us”, or “our”) is a company created to provide hosting and support for the PrairieLearn software at [prairielearn.com](/) (the "Site"). This document explains our policies regarding the collection, usage, processing, disclosure and security of your Personal Information when using the software provided by PrairieLearn, Inc. (the “Service”). By using the Site, you agree to the collection and use of information in accordance with this policy, which apply to all visitors, students, teachers, instructors, administrators, and others who access the Service (“Users”). If you are using the Site in accordance with a PrairieLearn contract with a university, school, college or legal entity (“Institution”), that Institution may separately require you to confirm acceptance of privacy and related provisions established by the Institution regarding your use of the Service.
+PrairieLearn is an open-source learning platform. PrairieLearn, Inc. (“we”, “us”, or “our”) is a company created to provide hosting and support for the PrairieLearn and PrairieTest software at [prairielearn.com](/), [prairietest.com](https://www.prairietest.com/), and associated subdomains (the "Sites"). This document explains our policies regarding the collection, usage, processing, disclosure and security of your Personal Information when using the software provided by PrairieLearn, Inc. (the “Service”). By using the Sites, you agree to the collection and use of information in accordance with this policy, which apply to all visitors, students, teachers, instructors, administrators, and others who access the Service (“Users”). If you are using the Sites in accordance with a PrairieLearn contract with a university, school, college or legal entity (“Institution”), that Institution may separately require you to confirm acceptance of privacy and related provisions established by the Institution regarding your use of the Service.
 
-We are the controller for Personal Information submitted to us under this Privacy Policy. PrairieLearn, Inc. takes its customers’ data privacy rights very seriously and has enacted this Policy to ensure those rights are maintained and protected.
+We are the controller for Personal Information submitted to us under this Privacy Policy for our own business purposes, such as support, billing, account administration, security, and business-contact records. When the Service is used by an Institution for course, exam, or other educational purposes, the Institution generally controls the education-record processing, and PrairieLearn processes those records under the Institution's agreement and instructions. PrairieLearn, Inc. takes its customers’ data privacy rights very seriously and has enacted this Policy to ensure those rights are maintained and protected.
 
 ## Revisions
 
-We will periodically review this Privacy Policy for accuracy and compliance, and we will notify you of these changes by posting them on the Site or by sending you an email. Any information that we collect is subject to the Privacy Policy in effect at the time you provide any Personal Information. You should review this Privacy Policy periodically.
+We will periodically review this Privacy Policy for accuracy and compliance, and we will notify you of these changes by posting them on the Sites or by sending you an email. Any information that we collect is subject to the Privacy Policy in effect at the time you provide any Personal Information. You should review this Privacy Policy periodically.
 
 ## Data collected and its usage
 
 ### Information provided by the User directly to PrairieLearn
 
-While using our Site, Users need to create an account or use their Institution login credentials. PrairieLearn may have access to certain personally identifiable information, hereinafter referred to as your “Personal Information”, that may include, but is not limited to the following: first and last name, email address and phone number, institution name, password, and credit card information. This Personal Information is used to carry out actions you request through the Site, such as user support, order history, and Service payment.
+While using our Sites, Users need to create an account or use their Institution login credentials. PrairieLearn may have access to certain personally identifiable information, hereinafter referred to as your “Personal Information”, that may include, but is not limited to the following: first and last name, email address and phone number, institution name, password, and credit card information. This Personal Information is used to carry out actions you request through the Sites, such as user support, order history, and Service payment.
 
 We also may retain information on your behalf, such as files and messages that you store using your account. If you provide us feedback or contact us via email, we will collect your name and email address, as well as any other content included in the email.
 
@@ -24,19 +24,19 @@ We also may retain information on your behalf, such as files and messages that y
 
 ### Information collected automatically related to the use of the Service
 
-When a User joins a course on the Services as a student, we get access to their email address and possibly their student identification number. In addition, we collect information about their interactions with the Site and their educational records, such as submitted assignments and corresponding scores. These User interactions on the Site while using the Service are referred as “Log Data”. PrairieLearn may send Log Data to a Learning Management System. Log Data may also include the User device’s Internet Protocol (“IP”) address, browser type, and operating system when using the Site. This information is used for purposes of providing the Service, validation and verification of a user account, tracking of transactions that you perform through the Site, security, improvement of the Services, and other purposes. We may use a person’s IP address to combat spam, malware, and identity theft, and to protect the integrity of the Service.
+When a User joins a course on the Services as a student, we get access to their email address and possibly their student identification number. In addition, we collect information about their interactions with the Sites and their educational records, such as submitted assignments and corresponding scores. If PrairieTest is used for exams, we may also process exam administration records needed to schedule, manage, secure, and audit exams, including records related to exam access and institution-provided accommodations. These User interactions on the Sites while using the Service are referred as “Log Data”. PrairieLearn may send Log Data to a Learning Management System. Log Data may also include the User device’s Internet Protocol (“IP”) address, browser type, and operating system when using the Sites. This information is used for purposes of providing the Service, validation and verification of a user account, tracking of transactions that you perform through the Sites, security, improvement of the Services, and other purposes. We may use a person’s IP address to combat spam, malware, and identity theft, and to protect the integrity of the Service.
 
 **De-identified information:** We may use the information we obtain via the Services (as described above) to create de-identified data, which is a collection of information where the User cannot be identified as an individual. Nothing in this Privacy Policy is intended to limit our ability to generate and use de-identified data, including aggregated de-identified information.
 
 ### Information collected using cookies
 
-Web Cookies are small pieces of data created by web servers and sent to your computer while you are browsing a website. We may use session cookies (which expire once you close your web browser) and persistent cookies (which stay on your computer until you delete them) to provide you with a more personal and interactive experience on our Site. Most web browsers are set to accept cookies by default. You may choose to set your web browser to refuse cookies, or to alert you when cookies are being sent. If you do so, note that some parts of our Site and Services may not function properly. We do not use web beacons or flash cookies.
+Web Cookies are small pieces of data created by web servers and sent to your computer while you are browsing a website. We may use session cookies (which expire once you close your web browser) and persistent cookies (which stay on your computer until you delete them) to provide you with a more personal and interactive experience on our Sites. Most web browsers are set to accept cookies by default. You may choose to set your web browser to refuse cookies, or to alert you when cookies are being sent. If you do so, note that some parts of our Sites and Services may not function properly. We do not use web beacons or flash cookies.
 
 ### Other general use of Personal Information
 
 In addition to the specific uses described above, we may also make use of Personal Information for the following purposes:
 
-- Improve the Site and our products and services;
+- Improve the Sites and our products and services;
 - Deliver and support our services and products;
 - Carry out transactions you have requested;
 - Perform auditing, data analysis, and research;
@@ -50,7 +50,7 @@ We will keep User’s Personal Information for as long as necessary to provide t
 
 We will not share any Personal Information that we have collected from you, except under these circumstances:
 
-- **Provide the Service:** We may share your Personal Information to third-parties for the sole purpose of providing you with the Services through our Site. For example, we may share data with service providers who host our websites or provide email services on our behalf.
+- **Provide the Service:** We may share your Personal Information to third-parties for the sole purpose of providing you with the Services through our Sites. For example, we may share data with service providers who host our websites or provide email services on our behalf.
 - **Research and Analysis:** We may share aggregated information and de-identified information with third parties for educational and industry research and analysis, demographic profiling, and other similar purposes.
 - **Information shared with Instructors/Teachers/Course Owners:** if you are a student who joined a course provided by the Service, all Personal Information may be shared with your instructors or educational institution via the functionalities of the Service, or upon request. Note that this includes all your assignments and corresponding scores, as well as IP addresses through which you accessed the Services.
 - **Information disclosed for our protection and the protection of others:** We cooperate with government and law enforcement officials or private parties to enforce and comply with the law. We may disclose any information about you to the government or law enforcement officials or private parties as we, in our sole discretion, believe necessary or appropriate: (i) to respond to claims and, legal process (including subpoenas); (ii) to protect our property, rights and safety and the property, rights, and safety of a third party or the public in general; and (iii) to stop any activity that we consider the illegal, unethical or legally actionable activity.
@@ -83,9 +83,9 @@ Our Services may contain links to other websites and services. Our Privacy Polic
 
 ## Changes to Personal Information
 
-You may change some of your personal information in your account by editing your profile within the Service. You may also request changes or deletions by emailing us at support@prairielearn.com. We will respond to your request, when permitted by law, within 30 days. We may be unable to delete information that resides in our archives.
+You may change some of your personal information in your account by editing your profile within the Service. You may also request changes or deletions for Personal Information that PrairieLearn controls by emailing us at support@prairielearn.com. We will respond to your request, when permitted by law, within 30 days. We may be unable to delete information that resides in our archives.
 
-If you are a student, we may be obligated to comply with requests from your instructor, course owner, or educational institution to change or delete the Personal Information associated with your Account. In addition, you may lose access to information from a particular course due to access rules specified by your instructor.
+If you are a student, requests about education records associated with a course or exam should generally be submitted to your instructor, course owner, or educational institution. We may be obligated to comply with requests from your instructor, course owner, or educational institution to change or delete the Personal Information associated with your Account. In addition, you may lose access to information from a particular course due to access rules specified by your instructor.
 
 ## International Customer Privacy
 

--- a/src/pages/legal/terms.mdx
+++ b/src/pages/legal/terms.mdx
@@ -6,7 +6,7 @@ export const meta = {
 
 Welcome to PrairieLearn! This document explains the terms of service (“Terms”) for using the PrairieLearn and PrairieTest software provided by PrairieLearn, Inc. (the “Service”). When you use the Service, you’re agreeing to all of the terms and conditions on this page. These Terms apply to all visitors, students, teachers, instructors, administrators, and others who access the Service (“Users”).
 
-PrairieLearn is an open-source learning platform. PrairieLearn, Inc. (“we”, “us”, or “our”) is a company created to provide hosting and support for PrairieLearn and PrairieTest software at [prairielearn.com](/) and [prairietest.com](https://www.prairietest.com/) (the "Site"). These Terms apply only to software hosted by PrairieLearn, Inc. If you use an instance of PrairieLearn hosted by another individual, company, organization, institution, or party, you will be bound by their terms and conditions, if specified.
+PrairieLearn is an open-source learning platform. PrairieLearn, Inc. (“we”, “us”, or “our”) is a company created to provide hosting and support for PrairieLearn and PrairieTest software at [prairielearn.com](/), [prairietest.com](https://www.prairietest.com/), and associated subdomains (the "Sites"). These Terms apply only to software hosted by PrairieLearn, Inc. If you use an instance of PrairieLearn hosted by another individual, company, organization, institution, or party, you will be bound by their terms and conditions, if specified.
 
 If your school, university, or organization has a separate agreement with PrairieLearn, Inc., that agreement will take precedence over these Terms.
 
@@ -87,7 +87,7 @@ You may terminate your account at any time by contacting support@prairielearn.co
 
 ## 8. Changes to Terms or Services
 
-We reserve the right to modify the Terms at any time. We will notify you about these changes by posting the modified Terms on the Site. If you continue to use the Services after we post the modified Terms on the Site, you agree to be bound by the modified Terms. It is your responsibility to review these changes when they are posted. If you do not agree to the new Terms, then you may stop using the Service.
+We reserve the right to modify the Terms at any time. We will notify you about these changes by posting the modified Terms on the Sites. If you continue to use the Services after we post the modified Terms on the Sites, you agree to be bound by the modified Terms. It is your responsibility to review these changes when they are posted. If you do not agree to the new Terms, then you may stop using the Service.
 
 ## 9. Feedback
 


### PR DESCRIPTION
# Description

Updates the legal privacy policy and terms to refer to PrairieLearn, PrairieTest, prairietest.com, and associated subdomains as Sites where appropriate. The privacy policy also clarifies PrairieLearn controller role for business purposes, institution-controlled education record processing, PrairieTest exam administration records, and how users should route education-record change or deletion requests.

# Testing

- Ran `git diff --cached --check`.
- Ran `pnpm lint`.
