### PR TITLE
Use dropdown on header nav for dual link buttons to PL/PT

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -105,13 +105,15 @@ export const Header: React.FC = () => {
           >
             <Dropdown.Item
               href="https://us.prairielearn.com/"
-              aria-label="Log in to PrairieLearn"
+              target="_blank"
+              aria-label="Log in to PrairieLearn (opens in a new tab)"
             >
               PrairieLearn
             </Dropdown.Item>
             <Dropdown.Item
               href="https://us.prairietest.com/"
-              aria-label="Log in to PrairieTest"
+              target="_blank"
+              aria-label="Log in to PrairieTest (opens in a new tab)"
             >
               PrairieTest
             </Dropdown.Item>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -105,14 +105,12 @@ export const Header: React.FC = () => {
           >
             <Dropdown.Item
               href="https://us.prairielearn.com/"
-              target="_blank"
               aria-label="Log in to PrairieLearn (opens in a new tab)"
             >
               PrairieLearn
             </Dropdown.Item>
             <Dropdown.Item
               href="https://us.prairietest.com/"
-              target="_blank"
               aria-label="Log in to PrairieTest (opens in a new tab)"
             >
               PrairieTest

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -96,12 +96,26 @@ export const Header: React.FC = () => {
           >
             Free sign up
           </button>
-          <a
-            href="https://us.prairielearn.com/pl/login"
-            className="btn btn-light btn-md me-3"
+          <DropdownButton
+            id="login-dropdown"
+            title="Login"
+            variant="light"
+            align="end"
+            className="d-inline-block me-3"
           >
-            Login
-          </a>
+            <Dropdown.Item
+              href="https://us.prairielearn.com/"
+              aria-label="Log in to PrairieLearn"
+            >
+              PrairieLearn
+            </Dropdown.Item>
+            <Dropdown.Item
+              href="https://us.prairietest.com/"
+              aria-label="Log in to PrairieTest"
+            >
+              PrairieTest
+            </Dropdown.Item>
+          </DropdownButton>
         </div>
       </div>
       <RequestCourseModal


### PR DESCRIPTION
# Description

Currently, the header nav has a singular link to PL, specifically the `/login` route.
Ideally, we can link to both PL and PT here, and exclude the `login` route to better support users who are already logged in.
This PR adds an accessible dropdown with links to both PL & PT.

# Testing
- Check out the updated header nav
- Observe the dropdown button and sub-buttons
    - Observe that clicking each takes you to the proper app